### PR TITLE
replace px by rem in media queries

### DIFF
--- a/src/components/About/About.module.css
+++ b/src/components/About/About.module.css
@@ -1,6 +1,5 @@
 .aboutSection {
   height: 100%;
-  text-align: justify;
 }
 .aboutContainer {
   display: flex;
@@ -42,7 +41,7 @@
   padding-top: 40px;
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 56.25rem) {
   .aboutSection {
     height: fit-content;
     padding-top: 80px;
@@ -133,7 +132,7 @@
   width: 48px;
 }
 
-@media only screen and (min-width: 1200px) {
+@media only screen and (min-width: 75rem) {
   .aboutInside {
     justify-content: unset;
   }

--- a/src/components/CardProject/CardProject.module.css
+++ b/src/components/CardProject/CardProject.module.css
@@ -4,7 +4,6 @@
   margin-top: 24px;
   padding: 16px 0;
   border-radius: 10px;
-  text-align: justify;
 }
 
 .containerCardProject:hover {
@@ -14,13 +13,15 @@
 .containerProjectInfo {
   display: flex;
   flex-direction: column;
+  padding-right: 16px;
+
 }
 
-@media only screen and (max-width: 900px) {
+/* @media only screen and (max-width: 56.25rem) {
   .containerProjectInfo {
     padding-right: 16px;
   }
-}
+} */
 
 .githubLink , .titleName {
   padding-right: 8px;
@@ -39,10 +40,10 @@
 
 .projectDescription {
   padding: 16px 0;
-  line-height: 24px;
+  line-height: 1.4rem;
 }
 
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: 37.5rem) {
   .containerImageProject {
     display: none;
   }
@@ -51,7 +52,7 @@
   }
 }
 
-@media only screen and (max-width: 450px) {
+@media only screen and (max-width: 28.125rem) {
   .projectDescription {
     padding: 16px 0;
   }

--- a/src/components/GroupProjects/GroupProjects.module.css
+++ b/src/components/GroupProjects/GroupProjects.module.css
@@ -8,13 +8,13 @@
   display: flex;
   flex-direction: column;
 }
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 56.25rem) {
   .containerGroupProjects {
 padding-top: 80px;
   }
 }
 
-@media only screen and (min-width: 1200px) {
+@media only screen and (min-width: 75rem) {
   .containerGroupProjects {
     min-height: 100%;
   }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -26,19 +26,19 @@
   cursor: pointer;
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 56.25rem) {
   .linkContainer {
     padding-top: 40px;
   }
 }
 
-@media only screen and (max-width: 750px) {
+@media only screen and (max-width: 46.875rem) {
   .headerContainer {
     padding-right: 0;
   }
 }
 
-@media only screen and (max-width: 450px) {
+@media only screen and (max-width: 28.125rem) {
   .textIntroduction {
     font-size: 1.5rem;
   }

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -25,7 +25,7 @@
   display: none;
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 56.25rem) {
   .layoutInside {
     display: flex;
     flex-direction: column;
@@ -42,13 +42,13 @@
   }
 }
 
-@media only screen and (max-width: 750px) {
+@media only screen and (max-width: 46.875rem) {
   .layoutInside {
     padding: 0 24px;
   }
 }
 
-@media only screen and (min-width: 1200px) {
+@media only screen and (min-width: 75rem) {
   .layoutContainer {
     align-items: center;
   }
@@ -57,7 +57,7 @@
   }
 }
 
-@media only screen and (min-width: 1600px) {
+@media only screen and (min-width: 100rem) {
   .layoutInside {
     width: 70%;
   }

--- a/src/components/NavBar/NavBar.module.css
+++ b/src/components/NavBar/NavBar.module.css
@@ -19,7 +19,7 @@
 }
 
 .navSpace {
-  margin-left: 16px;
+  margin-left: 32px;
   font-size: 1.5rem;
 
 }
@@ -38,7 +38,7 @@
 
 
 
-@media only screen and (max-width: 750px) {
+@media only screen and (max-width: 46.85rem) {
   .navigationInside {
     justify-content: flex-start;
     margin-right: 0;
@@ -55,14 +55,14 @@
 }
 
 
-@media(min-width:751px ) and (max-width: 900px) {
+@media(min-width:46.85rem ) and (max-width: 56.25rem) {
   .navigationInside {
     padding-right: 80px;
 
   }
 }
 
-@media only screen and (min-width: 1200px) {
+@media only screen and (min-width: 75rem) {
   .navigationContainer {
     justify-content: center;
   }
@@ -71,7 +71,7 @@
   }
 }
 
-@media only screen and (min-width: 1600px) {
+@media only screen and (min-width: 100rem) {
 
   .navigationInside {
     width: 70%;

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,9 +1,10 @@
+import { exo2, montserrat2 } from "@/styles/utils/fonts.ts";
 import styles from "./NavBar.module.css";
 import Link from "next/link";
 
 const NavBar = () => {
   return (
-    <nav className={styles.navigationContainer}>
+    <nav className={styles.navigationContainer} style={exo2.style}>
       <ul className={styles.navigationInside}>
         <li className={styles.navSpace}><Link href="#about">
           About

--- a/src/components/Skills/Skills.module.css
+++ b/src/components/Skills/Skills.module.css
@@ -21,7 +21,7 @@
   flex-direction: column;
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 56.25rem) {
   .skillsContainer {
     height: fit-content;
     padding-bottom: 40px;


### PR DESCRIPTION
This PR is improving accessibility on the portfolio:
- Set all text to alignment on the left
- Add line-height when missing
- Replace all media queries from pixels to rem

[TestAccessibility.pdf](https://github.com/user-attachments/files/18233010/TestAccessibility.pdf)
